### PR TITLE
fix: root component reactivity was not working, so the isEditing prop was always false

### DIFF
--- a/src/apresActivities/ActivityViewProvider.js
+++ b/src/apresActivities/ActivityViewProvider.js
@@ -17,7 +17,7 @@ export default class ActivityViewProvider {
         /** @type {import('vue').App<Element>} */
         let vueApp;
 
-        let props = reactive({ isEditing, domainObject })
+        let props = reactive({ isEditing: { value: isEditing }, domainObject })
 
         return {
             show: (element) => {
@@ -28,7 +28,7 @@ export default class ActivityViewProvider {
                 vueApp.mount(element)
             },
             onEditModeChange: (isEditing) => {
-                props.isEditing = isEditing
+                props.isEditing.value = isEditing
             },
             destroy: () => {
                 vueApp.unmount();

--- a/src/apresActivities/components/ActivityView.vue
+++ b/src/apresActivities/components/ActivityView.vue
@@ -23,7 +23,8 @@ export default {
     inject: ['openmct', 'objectPath'],
     props: {
         isEditing: {
-            type: Boolean
+            type: Object,
+            default: { value: false },
         },
         domainObject: {
             type: Object

--- a/src/timeline/TimelineViewProvider.js
+++ b/src/timeline/TimelineViewProvider.js
@@ -25,7 +25,7 @@ export default class TimelineViewProvider {
         /** @type {import('vue').ComponentPublicInstance} */
         let component;
         
-        let props = reactive({ isEditing, domainObject })
+        let props = reactive({ isEditing: { value: isEditing }, domainObject })
 
         return {
             type: 'apres-timeline',
@@ -39,7 +39,7 @@ export default class TimelineViewProvider {
                 component = vueApp.mount(element)
             },
             onEditModeChange: (isEditing) => {
-                props.isEditing = isEditing
+                props.isEditing.value = isEditing
             },
             destroy() {
                 vueApp.unmount();

--- a/src/timeline/components/ApresTimeline.vue
+++ b/src/timeline/components/ApresTimeline.vue
@@ -69,7 +69,7 @@
 					:activities="timelineLegends[legend]"
 					:parentDomainObject="liveDomainObject"
 					:index="index"
-					:isEditing="isEditing"
+					:isEditing="isEditing.value"
 					:startBounds="bounds.start"
 					:endBounds="bounds.end"
 					:pixelMultiplier="pixelMultiplier"
@@ -85,7 +85,7 @@
 					:chronicle="chronicle"
 					:parentDomainObject="liveDomainObject"
 					:index="index"
-					:isEditing="isEditing"
+					:isEditing="isEditing.value"
 					:startBounds="bounds.start"
 					:endBounds="bounds.end"
                     :projectEndTime="projectEndTime"
@@ -129,7 +129,8 @@ export default {
     inject: ['openmct', 'objectPath'],
     props: {
         isEditing: {
-            type: Boolean
+            type: Object,
+            default: { value: false }
         },
         domainObject: {
             type: Object


### PR DESCRIPTION
It is [not yet possible](https://github.com/vuejs/vue-next/issues/4874) to modify a root component's props in Vue 3. A simple workaround is to instead pass a sub-property that is reactive in the root component props.