### PR TITLE
Implements new persistence provider to work with apres service

### DIFF
--- a/src/lib/timelineUtil.js
+++ b/src/lib/timelineUtil.js
@@ -177,7 +177,7 @@ const timelineUtil = {
         const domainObject = {
             configuration: domainObjectConfiguration,
             identifier: {
-                key: 'test'
+                key: 'apres.timeline'
             },
             composition: [],
             location: 'mine',

--- a/src/persistence/localStorage/LocalStorageProvider.js
+++ b/src/persistence/localStorage/LocalStorageProvider.js
@@ -1,0 +1,84 @@
+const APRES_TIMELINE_KEY = 'apres.timeline';
+import axios from 'axios';
+import config from '../../../apresConfig.js';
+import timelineUtil from '../../lib/timelineUtil';
+import lodash from 'lodash';
+
+class LocalStorageProvider {
+    constructor(space, openmct) {
+        this.space = space || 'mct';
+        this.spaces = this.space ? [this.space] : [];
+        this.openmct = openmct;
+        this.localStorage = window.localStorage;
+    }
+
+    setValue(key, value) {
+        this.localStorage[key] = value;
+    }
+
+    getValue(key) {
+        return this.localStorage[key] !== undefined
+                ? JSON.parse(this.localStorage[key]) : {};
+    }
+
+    listSpaces() {
+        return Promise.resolve(this.spaces);
+    }
+
+    list() {
+        return Promise.resolve(Object.keys(this.getValue(this.space)));
+    }
+
+    create(model) {
+        var spaceObj = this.getValue(this.space);
+        spaceObj[model.identifier.key] = model;
+        this.setValue(this.space, JSON.stringify(spaceObj));
+
+
+        if (model.identifier.key === APRES_TIMELINE_KEY) {
+            const saveUrl = `${config['apres_service_root_url']}/save`;
+            const projectJSON = timelineUtil.getProjectJsonFromTimelineObject(model);
+
+            if (lodash.isEqual(projectJSON, this.cachedModel)) {
+                return Promise.resolve(true);
+            }
+    
+            this.cachedModel = projectJSON;
+
+            return axios.put(saveUrl, projectJSON).then((success) => {
+                this.openmct.notifications.info('Success: Project Saved to APRES Service.');
+            });
+        }
+
+        return Promise.resolve(true);
+    }
+
+    get(identifier) {
+        var spaceObj = this.getValue('mct');
+        const identifierWithNamespace = {
+            namespace: '',
+            key: identifier.key
+        };
+
+        const domainObject = {
+            ...spaceObj[identifier.key],
+            identifier: identifierWithNamespace,
+        };
+
+        return Promise.resolve(domainObject);
+    }
+
+    delete(identifier) {
+        var spaceObj = this.getValue(this.space);
+        delete spaceObj[identifier.key];
+        this.setValue(this.space, spaceObj);
+
+        return Promise.resolve(true);
+    }
+
+    update(model) {
+        return this.create(model);
+    }
+}
+
+export default LocalStorageProvider;

--- a/src/persistence/plugin.js
+++ b/src/persistence/plugin.js
@@ -1,0 +1,9 @@
+import LocalStorageProvider from './localStorage/LocalStorageProvider';
+const PERSISTENCE_SPACE = 'mct';
+
+export default function CouchPlugin(options) {
+    return function install(openmct) {
+        const localStorageProvider = new LocalStorageProvider(PERSISTENCE_SPACE, openmct);
+        openmct.objects.addProvider(PERSISTENCE_SPACE, localStorageProvider);
+    };
+}

--- a/src/startScreen/startScreen.vue
+++ b/src/startScreen/startScreen.vue
@@ -131,6 +131,7 @@ import openmct from 'openmct';
 import axios from 'axios';
 import apresTimeline from '../timeline/plugin'
 import apresActivities from '../apresActivities/plugin';
+import persistencePlugin from '../persistence/plugin';
 import apresDataset from '../apresDataset/plugin';
 import apresSessionIndicator from '../apresSessionIndicator/plugin';
 import config from '../../apresConfig.js';
@@ -192,8 +193,8 @@ export default {
             
             const actionAttributes = this.globalAttributes.modelAttributes && this.globalAttributes.modelAttributes.actionAttributes;
 
+            openmct.install(persistencePlugin());
             openmct.install(apresActivities(actionAttributes));
-            // openmct.install(apresStateChronicle());
             openmct.install(apresTimeline());
             openmct.install(apresDataset(projectJSON.configuration));
             openmct.install(apresSessionIndicator())
@@ -232,7 +233,6 @@ export default {
                 openmct.legacyRegistry.enable.bind(openmct.legacyRegistry)
             );
 
-            openmct.install(openmct.plugins.LocalStorage());
             openmct.install(openmct.plugins.Espresso());
             openmct.install(openmct.plugins.MyItems());
             openmct.install(openmct.plugins.Generator());

--- a/src/timeline/components/timeline.vue
+++ b/src/timeline/components/timeline.vue
@@ -197,7 +197,6 @@ export default {
 
             if (!this.domainObject.configuration.activities[keystring]) {
                 const configuration = lodash.cloneDeep(activityDomainObject.configuration);
-                let startTime;
 
                 if (!fromFile) {
                     configuration.startTime = this.timeFormatter.parse(this.domainObject.configuration.startTime);
@@ -306,7 +305,6 @@ export default {
                 zoomIn: this.zoomIn,
                 zoomOut: this.zoomOut,
                 importTimeline: this.importTimeline,
-                saveTimeline: this.saveTimeline,
                 deleteTimeline: this.deleteTimeline
             }
         },
@@ -505,14 +503,6 @@ export default {
         importTimeline() {
             this.openmct.$injector.get('dialogService')
                 .getUserInput(this.getFormModel(), {}).then(this.processJsonTimeline);
-        },
-        saveTimeline() {
-            const saveUrl = `${config['apres_service_root_url']}/save`;
-            const projectJSON = timelineUtil.getProjectJsonFromTimelineObject(this.domainObject);
-
-            axios.put(saveUrl, projectJSON).then((success) => {
-                this.openmct.notifications.info('Success: Project Saved to APRES Service.');
-            });
         },
         deleteTimeline() {
             const deleteUrl = `${config['apres_service_root_url']}/delete?projectname=${this.domainObject.name}`;

--- a/src/timeline/components/timelineActivity.vue
+++ b/src/timeline/components/timelineActivity.vue
@@ -222,6 +222,10 @@ export default {
             }
         },
         showContextMenu(event) {
+            if (!this.isEditing) {
+                return;
+            }
+
             const removeAction = this.getRemoveActionObject();
             this.openmct.menus.showMenu(event.x, event.y, [removeAction]);
         }

--- a/src/timeline/viewActions.js
+++ b/src/timeline/viewActions.js
@@ -42,17 +42,6 @@ const importTimeline = {
     group: 'view'
 }
 
-const saveTimeline = {
-    name: 'Save',
-    key: 'apres:save-timeline',
-    description: 'Save Timeline to APRES Service',
-    cssClass: 'icon-save',
-    invoke: (objectPath, viewProvider) => {
-        viewProvider.getViewContext().saveTimeline();
-    },
-    group: 'view'
-}
-
 const deleteTimeline = {
     name: 'Delete',
     key: 'apres:delete-timeline',
@@ -68,8 +57,7 @@ const viewActions = [
     importTimeline,
     centerTimeline,
     zoomIn,
-    zoomOut,,
-    saveTimeline,
+    zoomOut,
     deleteTimeline
 ];
 


### PR DESCRIPTION
This PR implements new persistence provider to make use of Open MCT's internal save system to persist files to the Apres Service. 

Now native save functionality in Open MCT will call the Apres Service persistence api to store timeline json.